### PR TITLE
Handler collisions

### DIFF
--- a/offline/handler_instance.go
+++ b/offline/handler_instance.go
@@ -51,7 +51,7 @@ func (handlerInstance *HandlerInstance) CompileHandler() (inputFilePaths []strin
 		Sourcemap:   api.SourceMapLinked,
 		Metafile:    true,
 		GlobalName:  "exports",
-		Outdir:      filepath.Join(workingDirectory, ".terrable"),
+		Outdir:      filepath.Join(workingDirectory, ".terrable", handlerInstance.handlerConfig.Name),
 	})
 
 	if len(result.Errors) > 0 {

--- a/samples/simple/simple-api.tf
+++ b/samples/simple/simple-api.tf
@@ -24,6 +24,22 @@ module "simple_api" {
         http = {
           GET = "/delayed",
         }
+    },
+
+    # These two handlers deliberately share a source file with the same name to verify
+    # they do not collide when transpiled into a "Collision.js" file
+
+    CollisionOne: {
+      source = "./src/Collision1/Collision.ts"
+        http = {
+          GET = "/collision1",
+        }
+    },
+    CollisionTwo: {
+      source = "./src/Collision2/Collision.ts"
+        http = {
+          GET = "/collision2",
+        }
     }
   }
 }

--- a/samples/simple/src/Collision1/Collision.ts
+++ b/samples/simple/src/Collision1/Collision.ts
@@ -1,0 +1,10 @@
+const handler = async (event) => {
+    return {
+        statusCode: 200,
+        body: JSON.stringify({
+            collision: "1"
+        }),
+    }
+}
+
+export { handler };

--- a/samples/simple/src/Collision2/Collision.ts
+++ b/samples/simple/src/Collision2/Collision.ts
@@ -1,0 +1,10 @@
+const handler = async (event) => {
+    return {
+        statusCode: 200,
+        body: JSON.stringify({
+            collision: "2"
+        }),
+    }
+}
+
+export { handler };

--- a/terrable_build
+++ b/terrable_build
@@ -1,1 +1,1 @@
-version = 0.1.8
+version = 0.1.9

--- a/tests/parallel/collision_test.hurl
+++ b/tests/parallel/collision_test.hurl
@@ -1,3 +1,6 @@
+# Ensures that two handlers configured with the same source file name 
+# work as intended and do not have any collisions when transpiled
+
 GET http://127.0.0.1:8081/collision1
 HTTP 200
 

--- a/tests/parallel/env_vars copy.hurl
+++ b/tests/parallel/env_vars copy.hurl
@@ -1,0 +1,11 @@
+GET http://127.0.0.1:8081/collision1
+HTTP 200
+
+[Asserts]
+jsonpath "$.collision" == "1"
+
+GET http://127.0.0.1:8081/collision2
+HTTP 200
+
+[Asserts]
+jsonpath "$.collision" == "2"


### PR DESCRIPTION
Place built source files into a directory corresponding to their handler name to avoid collisions.