### PR TITLE
Route prefix normalisation

### DIFF
--- a/offline/handler_server.go
+++ b/offline/handler_server.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/terrable-dev/terrable/utils"
+
 	"github.com/fatih/color"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -38,7 +40,7 @@ func ServeHandler(handlerInstance *HandlerInstance, r *mux.Router) {
 	defer np.Close()
 
 	for method, path := range handlerInstance.handlerConfig.Http {
-		go r.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		go r.HandleFunc(utils.NormalisePath(path), func(w http.ResponseWriter, r *http.Request) {
 			handlerExecutionMutex.Lock()
 			defer handlerExecutionMutex.Unlock()
 

--- a/offline/offline.go
+++ b/offline/offline.go
@@ -149,7 +149,6 @@ func printConfig(config config.TerrableConfig, port int) {
 			"",
 			"",
 		})
-
 	}
 
 	for _, handler := range config.Handlers {

--- a/offline/offline_test.go
+++ b/offline/offline_test.go
@@ -25,7 +25,14 @@ func TestPrintConfig(t *testing.T) {
 				Name:   "Handler2",
 				Source: "source2",
 				Http: map[string]string{
-					"GET": "/path2",
+					"GET": "path2",
+				},
+			},
+			{
+				Name:   "SqsHandler",
+				Source: "source3",
+				Sqs: map[string]string{
+					"queue": "arn:aws:sqs:region:account:queue",
 				},
 			},
 		},
@@ -50,11 +57,13 @@ func TestPrintConfig(t *testing.T) {
 
 	// Test for minimal required content without formatting
 	expectedEndpoints := []string{
-		"GET   http://localhost:1234/path1  (Handler1)",
-		"POST  http://localhost:1234/path1  (Handler1)",
-		"GET   http://localhost:1234/path2  (Handler2)",
+		"GET           http://localhost:1234/path1            (Handler1) ",
+		"POST          http://localhost:1234/path1            (Handler1) ",
+		"GET           http://localhost:1234path2             (Handler2) ",
+		"POST          http://localhost:1234/_sqs/SqsHandler  (SqsHandler)",
 	}
 
+	// Verify HTTP endpoints
 	for _, endpoint := range expectedEndpoints {
 		if !strings.Contains(output, strings.TrimSpace(endpoint)) {
 			t.Errorf("Expected output to contain endpoint '%s', but it doesn't.\nActual output:\n%s",

--- a/samples/simple/simple-api.tf
+++ b/samples/simple/simple-api.tf
@@ -28,15 +28,17 @@ module "simple_api" {
         }
         http = {
           GET = "/",
-          POST = "/"
+          POST = "/",
+          PUT = "",
         }
     },
 
     # Echo Handler configured with a callback-style instead of async / await
-      EchoCallback: {
+    EchoCallback: {
         source = "./src/EchoCallback.ts"
         http = {
           GET = "/echo-callback"
+          PUT = "echo-callback"
         }
     },
 

--- a/terrable_build
+++ b/terrable_build
@@ -1,1 +1,1 @@
-version = 0.5.0
+version = 0.6.0

--- a/tests/requests/route_normalisation.hurl
+++ b/tests/requests/route_normalisation.hurl
@@ -1,0 +1,8 @@
+# Some routes in the terrable configuration are deliberately missing trailing prefixes
+# These tests check that the routes are normalised correctly
+
+PUT http://127.0.0.1:8081/
+HTTP 200
+
+PUT http://127.0.0.1:8081/echo-callback
+HTTP 200

--- a/utils/normalise_path.go
+++ b/utils/normalise_path.go
@@ -1,0 +1,11 @@
+package utils
+
+import "strings"
+
+func NormalisePath(path string) string {
+	if !strings.HasPrefix(path, "/") {
+		return "/" + path
+	}
+
+	return path
+}

--- a/utils/normalise_path_test.go
+++ b/utils/normalise_path_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import "testing"
+
+func TestNormalisePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Empty path",
+			input:    "",
+			expected: "/",
+		},
+		{
+			name:     "Already normalised path",
+			input:    "/api/v1",
+			expected: "/api/v1",
+		},
+		{
+			name:     "Path without leading slash",
+			input:    "api/v1",
+			expected: "/api/v1",
+		},
+		{
+			name:     "Single character path",
+			input:    "a",
+			expected: "/a",
+		},
+		{
+			name:     "Path with special characters",
+			input:    "api-v1/users/{id}",
+			expected: "/api-v1/users/{id}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalisePath(tt.input)
+			if result != tt.expected {
+				t.Errorf("NormalisePath(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes offline configurations where a trailing prefix slash ('/') is missing from the path.